### PR TITLE
Stencil off-by-one and add/mult without modifying operands

### DIFF
--- a/src/foldBuilder/Expr.cpp
+++ b/src/foldBuilder/Expr.cpp
@@ -49,10 +49,13 @@ ExprPtr operator+(const ExprPtr& lhs, const ExprPtr& rhs) {
         return lhs;
 
     // If adding to another add result, just append an operand.
-    if (lhs->appendOp(rhs, AddExpr::opStr()))
-        return lhs;
-    if (rhs->appendOp(lhs, AddExpr::opStr()))
-        return rhs;
+    ExprPtr tmp_lhs = lhs->clone();
+    ExprPtr tmp_rhs = rhs->clone();
+    
+    if (tmp_lhs->appendOp(rhs, AddExpr::opStr()))
+        return tmp_lhs;
+    if (tmp_rhs->appendOp(lhs, AddExpr::opStr()))
+        return tmp_rhs;
 
     // Otherwise, make a new expression.
     else
@@ -83,10 +86,13 @@ ExprPtr operator*(const ExprPtr& lhs, const ExprPtr& rhs) {
         return lhs;
 
     // If multiplying by another mul result, just append an operand.
-    if (lhs->appendOp(rhs, MultExpr::opStr()))
-        return lhs;
-    if (rhs->appendOp(lhs, MultExpr::opStr()))
-        return rhs;
+    ExprPtr tmp_lhs = lhs->clone();
+    ExprPtr tmp_rhs = rhs->clone();
+    
+    if (tmp_lhs->appendOp(rhs, MultExpr::opStr()))
+        return tmp_lhs;
+    if (tmp_rhs->appendOp(lhs, MultExpr::opStr()))
+        return tmp_rhs;
 
     // Otherwise, make a new expression.
     else

--- a/src/foldBuilder/stencils/AwpStencil.hpp
+++ b/src/foldBuilder/stencils/AwpStencil.hpp
@@ -249,7 +249,7 @@ public:
             c2 * (vel_y(t+1, x,   y,   z+2) - vel_y(t+1, x,   y,   z-1));
         GridValue d_zy_val =
             c1 * (vel_z(t+1, x,   y+1, z  ) - vel_z(t+1, x,   y,   z  )) +
-            c2 * (vel_z(t+1, x,   y+1, z  ) - vel_z(t+1, x,   y-1, z  ));
+            c2 * (vel_z(t+1, x,   y+2, z  ) - vel_z(t+1, x,   y-1, z  ));
 
         GridValue next_stress_yz = stress_yz(t, x, y, z) +
             ((mu_val * delta_t / h) * (d_yz_val + d_zy_val));


### PR DESCRIPTION
Changes on index in AWP stencils to match the reference stencil.

Adds clone methods to Expr objects, and then uses these to prevent the addition / multiplication operator overloading from modifying the operands.