### PR TITLE
Add support for user specified code in StencilContext

### DIFF
--- a/src/foldBuilder/Print.cpp
+++ b/src/foldBuilder/Print.cpp
@@ -495,6 +495,15 @@ void YASKCppPrinter::printCode(ostream& os) {
         }
         os << " }" << endl;
 
+        // Stencil provided code for StencilContext
+        CodeList *extraCode;
+        if ( (extraCode = _stencil.getExtensionCode(STENCIL_CONTEXT)) != NULL )
+        {
+            os << endl << "  // Functions provided by user" << endl;
+            for ( auto code : *extraCode )
+                os << code << endl;
+        }
+        
         // end of context.
         os << "};" << endl;
     }

--- a/src/foldBuilder/stencils/StencilBase.hpp
+++ b/src/foldBuilder/stencils/StencilBase.hpp
@@ -31,6 +31,13 @@ IN THE SOFTWARE.
 #include <map>
 using namespace std;
 
+typedef enum { STENCIL_CONTEXT } YASKSection;
+typedef vector<string> CodeList;
+typedef map<YASKSection, CodeList > ExtensionsList;
+
+#define REGISTER_CODE_EXTENSION(section,code) _extensions[section].push_back(code);
+#define REGISTER_STENCIL_CONTEXT_EXTENSION(...) REGISTER_CODE_EXTENSION(STENCIL_CONTEXT,#__VA_ARGS__)
+
 class StencilBase;
 typedef map<string, StencilBase*> StencilList;
 
@@ -50,6 +57,10 @@ protected:
     // At this time, this is not checked, so be careful!!
     Params _params;     // keep track of all registered non-grid vars.
 
+    // Code extensions that overload default functions from YASK in the generated code for this 
+    // Stencil code
+    ExtensionsList _extensions;
+    
 public:
     virtual ~StencilBase() {}
 
@@ -74,6 +85,15 @@ public:
 
     // Define grid values relative to given offsets in each dimension.
     virtual void define(const IntTuple& offsets) = 0;
+    
+    CodeList * getExtensionCode ( YASKSection section ) 
+    { 
+        auto elem = _extensions.find(section);
+        if ( elem != _extensions.end() ) {
+            return &elem->second;
+        }
+        return NULL;
+    }
 };
 
 // A base class for stencils that have an 'radius'.

--- a/src/stencil_calc.hpp
+++ b/src/stencil_calc.hpp
@@ -216,6 +216,12 @@ namespace yask {
                        [&](RealGrid* gp, real_t seed){ gp->set_diff(seed); });
         }
 
+        // Init all grids & params 
+        // By default it uses the initSame initialization routine
+        virtual void init() {
+            initSame();
+        }
+
         // Compare grids in contexts.
         // Params should not be written to, so they are not compared.
         // Return number of mis-compares.

--- a/src/stencil_main.cpp
+++ b/src/stencil_main.cpp
@@ -670,7 +670,7 @@ int main(int argc, char** argv)
     // This will initialize the grids before running the warmup.  If this is
     // not done, some operations may be done on zero pages, leading to
     // misleading performance or arithmetic exceptions.
-    context.initSame();
+    context.init();
     *ostr << flush;
 
     // warmup caches, threading, etc.


### PR DESCRIPTION
This PR adds the basic infrastructure to associate code with the Stencil definition that will pass through YASK to the specific parts of the generated code.

For now it only defines a the StencilContext section which can be used for example to override the Grid initialization routines by adding the following code in the constructor of Stencil class:

        REGISTER_STENCIL_CONTEXT_EXTENSION(
                void init ( )
                {
                      initDiff();
                }
        );
