### PR TITLE
Make YASK pip-installable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,33 @@
+import subprocess
+import sys
+
+from setuptools import setup, find_packages
+from setuptools.command.install import install
+
+class Install(install):
+    """Customized setuptools install command - builds protos on install."""
+    def run(self):
+        protoc_command = ['make', 'compiler']
+        if subprocess.call(protoc_command) != 0:
+            sys.exit(-1)
+
+        protoc_command = ['make', 'compiler-api']
+        if subprocess.call(protoc_command) != 0:
+            sys.exit(-1)
+
+        install.run(self)
+
+setup(
+    name='yask',
+    version='v2-alpha',
+    description='YASK--Yet Another Stencil Kernel: '
+    'A framework to facilitate exploration of the HPC '
+    'stencil-performance design space',
+    url='https://01.org/yask',
+    author='Intel Corporation',
+    license='MIT',
+    package_dir = {'': 'lib'},
+    cmdclass={
+        'install': Install,
+    }
+)

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     url='https://01.org/yask',
     author='Intel Corporation',
     license='MIT',
-    package_dir = {'': 'lib'},
+    packages = ['yask'],
     cmdclass={
         'install': Install,
     }

--- a/src/compiler/Makefile
+++ b/src/compiler/Makefile
@@ -31,6 +31,7 @@ YASK_BASE	:=	$(shell cd ../..; pwd)
 LIB_DIR		:=	$(YASK_BASE)/lib
 INC_DIR		:=	$(YASK_BASE)/include
 BIN_DIR		:=	$(YASK_BASE)/bin
+YASK_DIR	:=	$(YASK_BASE)/yask
 
 # OS-specific
 ifeq ($(shell uname -o),Cygwin)
@@ -50,8 +51,8 @@ YC_MODULE	:=	$(YC_BASE)
 YC_EXEC		:=	$(BIN_DIR)/$(YC_BASE).exe
 YC_TEST_EXEC	:=	$(BIN_DIR)/$(YC_BASE)_api_test.exe
 YC_LIB		:=	$(LIB_DIR)/lib$(YC_BASE)$(SO_SUFFIX)
-YC_PY_LIB	:=	$(LIB_DIR)/_$(YC_MODULE)$(SO_SUFFIX)
-YC_PY_MOD	:=	$(LIB_DIR)/$(YC_MODULE).py
+YC_PY_LIB	:=	$(YASK_DIR)/_$(YC_MODULE)$(SO_SUFFIX)
+YC_PY_MOD	:=	$(YASK_DIR)/$(YC_MODULE).py
 
 # Common source.
 COMM_DIR	:=	../common
@@ -130,7 +131,7 @@ $(YC_SWIG_DIR)/yask_compiler_api_wrap.cpp: $(YC_SWIG_DIR)/yask*.i $(INC_DIR)/*.h
 	$(SWIG) -version
 	$(SWIG) -v -DYC_MODULE=$(YC_MODULE) -cppext cpp \
 	  -I$(INC_DIR) -I$(COMM_DIR) -I$(COMM_DIR)/swig \
-	  -c++ -python -outdir $(LIB_DIR) -builtin $<
+	  -c++ -python -outdir $(YASK_DIR) -builtin $<
 
 $(YC_SWIG_DIR)/yask_compiler_api_wrap.o: $(YC_SWIG_DIR)/yask_compiler_api_wrap.cpp
 	$(YC_CXX) $(YC_CXXFLAGS) $(PYINC) -fPIC -c -o $@ $<

--- a/src/kernel/Makefile
+++ b/src/kernel/Makefile
@@ -319,6 +319,7 @@ YASK_BASE	:=	$(shell cd ../..; pwd)
 LIB_DIR		:=	$(YASK_BASE)/lib
 INC_DIR		:=	$(YASK_BASE)/include
 BIN_DIR		:=	$(YASK_BASE)/bin
+YASK_DIR	:=	$(YASK_BASE)/yask
 
 # OS-specific
 ifeq ($(shell uname -o),Cygwin)
@@ -339,8 +340,8 @@ YK_TAG		:=	$(stencil).$(arch)
 YK_BASE2	:=	$(YK_BASE).$(YK_TAG)
 YK_EXEC		:=	$(BIN_DIR)/$(YK_BASE2).exe
 YK_LIB		:=	$(LIB_DIR)/lib$(YK_BASE2)$(SO_SUFFIX)
-YK_PY_LIB	:=	$(LIB_DIR)/_$(YK_MODULE)$(SO_SUFFIX)
-YK_PY_MOD	:=	$(LIB_DIR)/$(YK_MODULE).py
+YK_PY_LIB	:=	$(YASK_DIR)/_$(YK_MODULE)$(SO_SUFFIX)
+YK_PY_MOD	:=	$(YASK_DIR)/$(YK_MODULE).py
 YK_API_TEST_EXEC :=	$(BIN_DIR)/$(YK_BASE)_api_test.exe
 YK_GRID_TEST_EXEC :=	$(BIN_DIR)/$(YK_BASE)_grid_test.exe
 YK_TUPLE_TEST_EXEC :=	$(BIN_DIR)/$(YK_BASE)_tuple_test.exe
@@ -598,7 +599,7 @@ $(YK_SWIG_DIR)/yask_kernel_api_wrap.cpp: $(YK_SWIG_DIR)/yask*.i $(INC_DIR)/*.hpp
 	$(SWIG) -version
 	$(SWIG) -v -DYK_MODULE=$(YK_MODULE) -cppext cpp \
 	  -I$(INC_DIR) -I$(COMM_DIR) -I$(COMM_DIR)/swig \
-	  -c++ -python -outdir $(LIB_DIR) -builtin $<
+	  -c++ -python -outdir $(YASK_DIR) -builtin $<
 
 $(YK_SWIG_DIR)/yask_kernel_api_wrap.o: $(YK_SWIG_DIR)/yask_kernel_api_wrap.cpp
 	$(YK_CXX) $(YK_CXXFLAGS) $(PYINC) -fPIC -c -o $@ $<

--- a/yask/__init__.py
+++ b/yask/__init__.py
@@ -1,0 +1,1 @@
+import yask_compiler as compiler  # noqa


### PR DESCRIPTION
Preliminary install machinery for `pip` installs. This currently still requires YASK to be installed in "editable" mode (`pip -e`) so that runtime-generated SWIG modules can be picked up seamlessly. It also installs all Python modules into `yask/yask` now to mirror Python conventions and allow imports of the form:
```
from yask import compiler

<generate my_yask_kernel>
from yask import my_yask_kernel
``` 